### PR TITLE
セキュリティのセッティングを実施。

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,6 +19,8 @@ services:
         container_name: ${container_name_nginx}
         image: nginx:${version_of_nginx}
         volumes:
+            - ./nginx/publich:/hostos/publich/
+            - ./nginx/config/nginx.conf:/etc/nginx/nginx.conf
             - ./nginx/config/flask_app.conf:/etc/nginx/conf.d/flask_app.conf
         ports:
             - "${port_of_nginx}"

--- a/docker/nginx/config/flask_app.conf
+++ b/docker/nginx/config/flask_app.conf
@@ -1,7 +1,7 @@
 server {
     listen 80 default_server;
+    server_name nginx;
     charset utf-8;
-    server_tokens off;
     
     location / {
         proxy_pass http://flask:3031;
@@ -9,6 +9,11 @@ server {
     }
     location /static {
         alias /static;
+    }
+    location = /favicon.ico {
+        access_log off;
+        empty_gif;
+        expires 30d;
     }
 
 }

--- a/docker/nginx/config/nginx.conf
+++ b/docker/nginx/config/nginx.conf
@@ -1,0 +1,32 @@
+
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    server_tokens off;
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/flask_app.conf;
+}


### PR DESCRIPTION
主にnginx.confの更新。
Get,Post時にserverの情報を与えないよう`server_tokens off`の設定を追加。
余計なセッティングを読み込まないよう`include /etc/nginx/conf.d/flask_app.conf`により、
読み込む外部セッティングを指定可。
favicon.icoの404エラーが邪魔なため、ログに残さないように設定。
後ほど無くすが、共有フォルダを設定し必要なセッティングファイル等を
すぐにでも取り出せるように変更。

flask_app.confの余計な設定を取り消し。